### PR TITLE
fix: improve error handling in provider configuration

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -139,14 +139,14 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 
 	if clientID == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("host"),
-			"Missing Foundry API clientID", "Please provide the API clientID for Foundry in the provider configuration.")
+			path.Root("client_id"),
+			"Missing Foundry API Client ID", "Please provide the API Client ID for Foundry in the provider configuration.")
 	}
 
 	if clientSecret == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("host"),
-			"Missing Foundry API clientSecret", "Please provide the API clientSecret for Foundry in the provider configuration.")
+			path.Root("client_secret"),
+			"Missing Foundry API Client Secret", "Please provide the API Client Secret for Foundry in the provider configuration.")
 	}
 
 	if resp.Diagnostics.HasError() {
@@ -156,25 +156,26 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 	tokenString, err := auth.GetAuthToken(host, clientID, clientSecret)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to retrieve Foundry API Token",
-			"Unable to retrieve Foundry API Token: "+err.Error(),
+			"Authentication Failed",
+			"Failed to retrieve authentication token from Foundry API. Please verify your client credentials and host configuration. Error: "+err.Error(),
 		)
+		return
 	}
 
 	token, err := securityprovider.NewSecurityProviderBearerToken(tokenString)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to convert Foundry API Token",
-			"Unable to convert Foundry API Token: "+err.Error(),
+			"Token Processing Failed",
+			"Failed to create security provider from authentication token. Error: "+err.Error(),
 		)
 		return
 	}
+	
 	client, err := v2.NewClientWithResponses(host+"api", v2.WithRequestEditorFn(token.Intercept))
-
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to create Foundry API Client",
-			"Unable to create Foundry API Client: "+err.Error(),
+			"Client Creation Failed",
+			"Failed to create Foundry API client. Please verify the host URL is correct and accessible. Error: "+err.Error(),
 		)
 		return
 	}


### PR DESCRIPTION
## Description

The provider configuration currently has incorrect path references for `client_id` and `client_secret` validation errors.
Both error messages incorrectly reference `path.Root("host")` instead of their respective attribute paths, leading to misleading guidance for users.

---

## Location

* File: `internal/provider/provider.go`
* Lines: **141–143**, **147–149**

---

## Current Code (Problematic)

```go
if clientID == "" {
    resp.Diagnostics.AddAttributeError(
        path.Root("host"),  // ❌ Wrong path reference
        "Missing Foundry API clientID", "Please provide the API clientID for Foundry in the provider configuration.")
}

if clientSecret == "" {
    resp.Diagnostics.AddAttributeError(
        path.Root("host"),  // ❌ Wrong path reference
        "Missing Foundry API clientSecret", "Please provide the API clientSecret for Foundry in the provider configuration.")
}
```

---

## Impact

* Error messages point to the **wrong configuration attribute**
* Users receive **misleading troubleshooting guidance**
* Terraform error highlighting shows the **incorrect field**

---

## Expected Behavior

Error messages should reference the **correct attribute paths** and provide clear guidance, including available environment variable alternatives.

### Fixed Example

```go
if clientID == "" {
    resp.Diagnostics.AddAttributeError(
        path.Root("client_id"),  // ✅ Correct path
        "Missing Foundry API Client ID", 
        "The Foundry API Client ID must be provided via the 'client_id' attribute or the CLIENT_ID environment variable.")
}

if clientSecret == "" {
    resp.Diagnostics.AddAttributeError(
        path.Root("client_secret"),  // ✅ Correct path
        "Missing Foundry API Client Secret", 
        "The Foundry API Client Secret must be provided via the 'client_secret' attribute or the CLIENT_SECRET environment variable.")
}
```

---

## Additional Improvements Suggested

1. Add missing `return` after authentication token retrieval failure.
2. Improve error message consistency (capitalization, attribute naming).
3. Add environment variable guidance in all error messages for clarity.

---

✅ This fix will ensure users receive **accurate, actionable guidance** when configuring the provider, reducing confusion and setup errors.