### PR TITLE
Disable Organization And Enrollment Admin Requirements On Update When deletions_disabled Is True

### DIFF
--- a/internal/provider/enrollment/resource.go
+++ b/internal/provider/enrollment/resource.go
@@ -238,7 +238,7 @@ func (r *enrollmentResource) UpdateEnrollmentRoles(ctx context.Context, plan *en
 			break
 		}
 	}
-	if !hasAdmin {
+	if !hasAdmin && !r.deletionsDisabled {
 		return fmt.Errorf("the Enrollment must have at least one Administrator")
 	}
 

--- a/internal/provider/organization/resource.go
+++ b/internal/provider/organization/resource.go
@@ -687,7 +687,7 @@ func (r *organizationResource) UpdateOrganizationRoles(ctx context.Context, plan
 			break
 		}
 	}
-	if !hasAdmin {
+	if !hasAdmin && !r.deletionsDisabled {
 		return fmt.Errorf("the Organization must have at least one administrator")
 	}
 


### PR DESCRIPTION
…te with deletions_disabled true

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Disable organization and enrollment admin requirements on update when deletions_disabled is true.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

