### PR TITLE
Use service discovery to infer hostnames

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
 provider "foundry" {
     client_id = "your-client-id-here"                 # may be specified with CLIENT_ID environment variable
     client_secret = "your-client-secret-here"         # may be specified with CLIENT_SECRET environment variable
-    host = "https://example.palantirfoundry.com/"     # may be specified with BASE_HOSTNAME environment variable
+    host = "https://example.palantirfoundry.com/"     # may be specified with BASE_HOSTNAME environment variable or omitted entirely when running as a Foundry build inside the targeted enrollment
 }
 ```
 
@@ -34,7 +34,7 @@ provider "foundry" {
 
 ### Optional
 
-- `client_id` (String)
-- `client_secret` (String, Sensitive)
+- `client_id` (String) The Client ID of a [Foundry OAuth client](https://www.palantir.com/docs/foundry/ontology-sdk/oauth-clients/). If no value is set here, the provider will look for the `CLIENT_ID` environment variable.
+- `client_secret` (String, Sensitive) The Client Secret of a [Foundry OAuth client](https://www.palantir.com/docs/foundry/ontology-sdk/oauth-clients/). If no value is set here, the provider will look for the `CLIENT_SECRET` environment variable.
 - `deletions_disabled` (Boolean) An experimental provider-level flag to fully disable deletions of resources as well as the removal of resources' associated roles, members, etc.. This puts the provider a sort of `safe-mode`, preventing the removal of existing infra which can be subject to change outside the scope of your IAC management. In this mode, drift between the actual external infrastructure state and terraform's state is accepted, and applied plans might not map 1:1 with reality. As such, this flag must be used with caution. When a deletion operation is initiated on an otherwise deletable object (currently space, group, or project) and this flag is set to true then we will not remove the remote resource but will still remove remove the resource from state. On non-deletable resources, this flag being set to true will allow said resources to be removed from state while keeping the remote resource intact.
-- `host` (String)
+- `host` (String) The base URL for the Foundry enrollment. Example: `https://example.palantirfoundry.com/`. If no value is set here, the provider will look for the `BASE_HOSTNAME` environment variable. When running terraform as a build from inside the targeted Foundry enrollment, this may be omitted entirely and the provider will infer the correct host automatically.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -10,5 +10,5 @@ terraform {
 provider "foundry" {
     client_id = "your-client-id-here"                 # may be specified with CLIENT_ID environment variable
     client_secret = "your-client-secret-here"         # may be specified with CLIENT_SECRET environment variable
-    host = "https://example.palantirfoundry.com/"     # may be specified with BASE_HOSTNAME environment variable
+    host = "https://example.palantirfoundry.com/"     # may be specified with BASE_HOSTNAME environment variable or omitted entirely when running as a Foundry build inside the targeted enrollment
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.2
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -91,6 +92,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.77.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/auth/confidential_client_auth.go
+++ b/internal/auth/confidential_client_auth.go
@@ -29,7 +29,7 @@ type OAuth2TokenResponse struct {
 	AccessToken string `json:"access_token"`
 }
 
-func GetAuthToken(hostname string, clientID string, clientSecret string) (string, error) {
+func GetAuthToken(multipassApiUrl string, clientID string, clientSecret string) (string, error) {
 
 	//get the token itself
 	formData := url.Values{}
@@ -39,7 +39,7 @@ func GetAuthToken(hostname string, clientID string, clientSecret string) (string
 
 	encodedData := formData.Encode()
 
-	endpoint := fmt.Sprintf("%smultipass/api/oauth2/token", hostname)
+	endpoint := fmt.Sprintf("%s/oauth2/token", multipassApiUrl)
 
 	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(encodedData))
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,14 +61,17 @@ func (p *FoundryProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 		Description: "Interact with Foundry.",
 		Attributes: map[string]schema.Attribute{
 			"host": schema.StringAttribute{
-				Optional: true,
+				Optional:    true,
+				Description: "The base URL for the Foundry enrollment. Example: `https://example.palantirfoundry.com/`. If no value is set here, the provider will look for the `BASE_HOSTNAME` environment variable. When running terraform as a build from inside the targeted Foundry enrollment, this may be omitted entirely and the provider will infer the correct host automatically.",
 			},
 			"client_id": schema.StringAttribute{
-				Optional: true,
+				Optional:    true,
+				Description: "The Client ID of a [Foundry OAuth client](https://www.palantir.com/docs/foundry/ontology-sdk/oauth-clients/). If no value is set here, the provider will look for the `CLIENT_ID` environment variable.",
 			},
 			"client_secret": schema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "The Client Secret of a [Foundry OAuth client](https://www.palantir.com/docs/foundry/ontology-sdk/oauth-clients/). If no value is set here, the provider will look for the `CLIENT_SECRET` environment variable.",
 			},
 			"deletions_disabled": schema.BoolAttribute{
 				Optional:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -120,12 +120,8 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	// Default values to environment variables, but override
-	// with Terraform configuration value if set.
-
-	host := os.Getenv("BASE_HOSTNAME")
-	clientID := os.Getenv("CLIENT_ID")
-	clientSecret := os.Getenv("CLIENT_SECRET")
+	clientID := config.ClientID.ValueString()
+	clientSecret := config.ClientSecret.ValueString()
 
 	// If no deletionsDisabled flag provided, default to false.
 	var deletionsDisabled bool
@@ -135,22 +131,17 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 		deletionsDisabled = config.DeletionsDisabled.ValueBool()
 	}
 
-	if !config.Host.IsNull() {
-		host = config.Host.ValueString()
+	// Fallback to environment variables if values not set in config
+	if clientID == "" {
+		clientID = os.Getenv("CLIENT_ID")
 	}
 
-	if !config.ClientID.IsNull() {
-		clientID = config.ClientID.ValueString()
+	if clientSecret == "" {
+		clientSecret = os.Getenv("CLIENT_SECRET")
 	}
 
-	if !config.ClientSecret.IsNull() {
-		clientSecret = config.ClientSecret.ValueString()
-	}
-
-	// If any of the expected configurations are missing, return
-	// errors with provider-specific guidance.
-
-	if host == "" {
+	configUrls := ResolveUrls(config)
+	if configUrls == nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("host"),
 			"Missing Foundry API Host", "Please provide the API host for Foundry in the provider configuration.")
@@ -158,13 +149,13 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 
 	if clientID == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("host"),
+			path.Root("clientId"),
 			"Missing Foundry API clientID", "Please provide the API clientID for Foundry in the provider configuration.")
 	}
 
 	if clientSecret == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("host"),
+			path.Root("clientSecret"),
 			"Missing Foundry API clientSecret", "Please provide the API clientSecret for Foundry in the provider configuration.")
 	}
 
@@ -172,7 +163,7 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	tokenString, err := auth.GetAuthToken(host, clientID, clientSecret)
+	tokenString, err := auth.GetAuthToken(configUrls.MultipassUrl, clientID, clientSecret)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to retrieve Foundry API Token",
@@ -188,7 +179,7 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 		)
 		return
 	}
-	client, err := v2.NewClientWithResponses(host+"api", v2.WithRequestEditorFn(token.Intercept))
+	client, err := v2.NewClientWithResponses(configUrls.ApiGatewayUrl, v2.WithRequestEditorFn(token.Intercept))
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -32,6 +32,7 @@ import (
 	"github.com/palantir/terraform-provider-palantir-foundry/internal/provider/marking"
 	"github.com/palantir/terraform-provider-palantir-foundry/internal/provider/organization"
 	"github.com/palantir/terraform-provider-palantir-foundry/internal/provider/project"
+	"github.com/palantir/terraform-provider-palantir-foundry/internal/provider/services"
 	"github.com/palantir/terraform-provider-palantir-foundry/internal/provider/shared"
 	"github.com/palantir/terraform-provider-palantir-foundry/internal/provider/space"
 )
@@ -140,7 +141,7 @@ func (p *FoundryProvider) Configure(ctx context.Context, req provider.ConfigureR
 		clientSecret = os.Getenv("CLIENT_SECRET")
 	}
 
-	configUrls := ResolveUrls(config)
+	configUrls := services.ResolveUrls(config.Host.ValueString())
 	if configUrls == nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("host"),

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type ResolvedServiceUrls struct {
+	ApiGatewayUrl string
+	MultipassUrl  string
+}
+
+type serviceDiscovery struct {
+	Multipass  []string `yaml:"multipass"`
+	ApiGateway []string `yaml:"api_gateway"`
+}
+
+func ResolveUrls(config foundryProviderModel) *ResolvedServiceUrls {
+	host := config.Host.ValueString()
+	if host == "" {
+		host = os.Getenv("BASE_HOSTNAME")
+	}
+
+	if host != "" {
+		return &ResolvedServiceUrls{
+			ApiGatewayUrl: host + "api",
+			MultipassUrl:  host + "multipass/api",
+		}
+	}
+
+	serviceDiscoveryPath := os.Getenv("FOUNDRY_SERVICE_DISCOVERY_V2")
+	if serviceDiscoveryPath != "" {
+		yamlFile, err := os.ReadFile(serviceDiscoveryPath)
+		if err != nil {
+			panic(err)
+		}
+		var config serviceDiscovery
+		err = yaml.Unmarshal(yamlFile, &config)
+		if err != nil {
+			panic(err)
+		}
+
+		return &ResolvedServiceUrls{
+			ApiGatewayUrl: config.ApiGateway[0],
+			MultipassUrl:  config.Multipass[0],
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/services/services.go
+++ b/internal/provider/services/services.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package services
 
 import (

--- a/internal/provider/services/services.go
+++ b/internal/provider/services/services.go
@@ -1,4 +1,4 @@
-package provider
+package services
 
 import (
 	"os"
@@ -16,8 +16,8 @@ type serviceDiscovery struct {
 	ApiGateway []string `yaml:"api_gateway"`
 }
 
-func ResolveUrls(config foundryProviderModel) *ResolvedServiceUrls {
-	host := config.Host.ValueString()
+func ResolveUrls(configHost string) *ResolvedServiceUrls {
+	host := configHost
 	if host == "" {
 		host = os.Getenv("BASE_HOSTNAME")
 	}

--- a/internal/provider/services/services_test.go
+++ b/internal/provider/services/services_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package services
 
 import (
@@ -10,7 +24,9 @@ func TestResolveUrlsServiceDiscovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
-	defer os.Remove(serviceDiscoveryFile.Name())
+	defer func() {
+		_ = os.Remove(serviceDiscoveryFile.Name())
+	}()
 
 	serviceDiscoveryContent := `
 api_gateway:
@@ -23,8 +39,10 @@ multipass:
 		t.Fatalf("Failed to write to temp file: %v", err)
 	}
 
-	os.Setenv("FOUNDRY_SERVICE_DISCOVERY_V2", serviceDiscoveryFile.Name())
-	defer os.Unsetenv("FOUNDRY_SERVICE_DISCOVERY_V2")
+	_ = os.Setenv("FOUNDRY_SERVICE_DISCOVERY_V2", serviceDiscoveryFile.Name())
+	defer func() {
+		_ = os.Unsetenv("FOUNDRY_SERVICE_DISCOVERY_V2")
+	}()
 
 	urls := ResolveUrls("")
 
@@ -57,8 +75,10 @@ func TestResolveUrlsConfigHost(t *testing.T) {
 
 func TestResolveUrlsEnvBaseHostname(t *testing.T) {
 	baseHostname := "https://env.host/foundry/"
-	os.Setenv("BASE_HOSTNAME", baseHostname)
-	defer os.Unsetenv("BASE_HOSTNAME")
+	_ = os.Setenv("BASE_HOSTNAME", baseHostname)
+	defer func() {
+		_ = os.Unsetenv("BASE_HOSTNAME")
+	}()
 
 	urls := ResolveUrls("")
 
@@ -74,8 +94,8 @@ func TestResolveUrlsEnvBaseHostname(t *testing.T) {
 }
 
 func TestResolveUrlsNoConfig(t *testing.T) {
-	os.Unsetenv("BASE_HOSTNAME")
-	os.Unsetenv("FOUNDRY_SERVICE_DISCOVERY_V2")
+	_ = os.Unsetenv("BASE_HOSTNAME")
+	_ = os.Unsetenv("FOUNDRY_SERVICE_DISCOVERY_V2")
 
 	urls := ResolveUrls("")
 

--- a/internal/provider/services/services_test.go
+++ b/internal/provider/services/services_test.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveUrlsServiceDiscovery(t *testing.T) {
+	serviceDiscoveryFile, err := os.CreateTemp("", "service_discovery_*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(serviceDiscoveryFile.Name())
+
+	serviceDiscoveryContent := `
+api_gateway:
+    - https://in.cluster.service.local:8443/compute/jkhe23/foundry/api-gateway/api
+multipass:
+    - https://other.cluster.service.local:8443/compute/ad89721/multipass/api
+`
+	_, err = serviceDiscoveryFile.WriteString(serviceDiscoveryContent)
+	if err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+
+	os.Setenv("FOUNDRY_SERVICE_DISCOVERY_V2", serviceDiscoveryFile.Name())
+	defer os.Unsetenv("FOUNDRY_SERVICE_DISCOVERY_V2")
+
+	urls := ResolveUrls("")
+
+	expectedApiGatewayUrl := "https://in.cluster.service.local:8443/compute/jkhe23/foundry/api-gateway/api"
+	expectedMultipassUrl := "https://other.cluster.service.local:8443/compute/ad89721/multipass/api"
+
+	if urls.ApiGatewayUrl != expectedApiGatewayUrl {
+		t.Errorf("Expected ApiGatewayUrl %s, got %s", expectedApiGatewayUrl, urls.ApiGatewayUrl)
+	}
+	if urls.MultipassUrl != expectedMultipassUrl {
+		t.Errorf("Expected MultipassUrl %s, got %s", expectedMultipassUrl, urls.MultipassUrl)
+	}
+}
+
+func TestResolveUrlsConfigHost(t *testing.T) {
+	configHost := "https://custom.host/foundry/"
+
+	urls := ResolveUrls(configHost)
+
+	expectedApiGatewayUrl := "https://custom.host/foundry/api"
+	expectedMultipassUrl := "https://custom.host/foundry/multipass/api"
+
+	if urls.ApiGatewayUrl != expectedApiGatewayUrl {
+		t.Errorf("Expected ApiGatewayUrl %s, got %s", expectedApiGatewayUrl, urls.ApiGatewayUrl)
+	}
+	if urls.MultipassUrl != expectedMultipassUrl {
+		t.Errorf("Expected MultipassUrl %s, got %s", expectedMultipassUrl, urls.MultipassUrl)
+	}
+}
+
+func TestResolveUrlsEnvBaseHostname(t *testing.T) {
+	baseHostname := "https://env.host/foundry/"
+	os.Setenv("BASE_HOSTNAME", baseHostname)
+	defer os.Unsetenv("BASE_HOSTNAME")
+
+	urls := ResolveUrls("")
+
+	expectedApiGatewayUrl := "https://env.host/foundry/api"
+	expectedMultipassUrl := "https://env.host/foundry/multipass/api"
+
+	if urls.ApiGatewayUrl != expectedApiGatewayUrl {
+		t.Errorf("Expected ApiGatewayUrl %s, got %s", expectedApiGatewayUrl, urls.ApiGatewayUrl)
+	}
+	if urls.MultipassUrl != expectedMultipassUrl {
+		t.Errorf("Expected MultipassUrl %s, got %s", expectedMultipassUrl, urls.MultipassUrl)
+	}
+}
+
+func TestResolveUrlsNoConfig(t *testing.T) {
+	os.Unsetenv("BASE_HOSTNAME")
+	os.Unsetenv("FOUNDRY_SERVICE_DISCOVERY_V2")
+
+	urls := ResolveUrls("")
+
+	if urls != nil {
+		t.Errorf("Expected nil URLs, got %v", urls)
+	}
+}


### PR DESCRIPTION
## Background
Network egress out of Foundry environments is blocked by default. Even hitting the primary domain of a Foundry environment (e.g. `example.palantirfoundry.com`) is technically a network egress and is blocked by default.

For requests to Foundry backend services, special in-cluster URLs can be used that do not need to go through the primary domain of the environment. Each backend has a different in-cluster URL. These URLs can be discovered by reading the YAML file at the path specified by the `FOUNDRY_SERVICE_DISCOVERY_V2` environment variable.

## After this PR
==COMMIT_MSG==
Use service discovery to fall back to in-cluster URLs when running inside a Foundry environment
==COMMIT_MSG==

The resolution order for `host` is now:
* value specified in provider configuration files
* The `BASE_HOSTNAME` environment variable
* Service discovery
