### PR TITLE
Ignore Windows/ARM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
-          version: latest
+          version: 2.14.1
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -29,6 +29,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -30,7 +30,7 @@ builds:
     - goos: darwin
       goarch: '386'
     - goos: windows
-      goarch: arm64
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Go has dropped support for windows/arm, but goreleaser is still trying to build this combination

https://github.com/golang/go/issues/71671